### PR TITLE
Add a fix for ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,27 +280,30 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 
-# Run sphinx-apidoc before building docs.
 def run_apidoc(_):
-    import sphinx.apidoc
-
     ignore_paths = [
-        "../setup.py",
-        "../tests",
-        "../travis_pypi_setup.py",
-        "../versioneer.py"
+        ...
     ]
-    sphinx.apidoc.main(
-        [
-            sphinx.apidoc.__file__,
-            "-f",
-            "-T",
-            "-e",
-            "-M",
-            "-o", ".",
-            ".."
-        ] + ignore_paths
-    )
+
+    argv = [
+        "-f",
+        "-T",
+        "-e",
+        "-M",
+        "-o", ".",
+        ".."
+    ] + ignore_paths
+
+    try:
+        # Sphinx 1.7+
+        from sphinx.ext import apidoc
+    except ImportError:
+        # Sphinx 1.6 (and earlier)
+        from sphinx import apidoc
+        argv.insert(0, apidoc.__file__)
+
+    apidoc.main(argv)
+
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)


### PR DESCRIPTION
Adjust how `sphinx-apidoc` is run from `conf.py` to handle incompatibilities between Sphinx pre-1.7 and post-1.7.

Borrowed from [our comment]( https://github.com/rtfd/readthedocs.org/issues/1139#issuecomment-398083449 ).