### PR TITLE
Fix some typos in `docs/conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,9 +280,13 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 
+# Run sphinx-apidoc before building docs.
 def run_apidoc(_):
     ignore_paths = [
-        ...
+        "../setup.py",
+        "../tests",
+        "../travis_pypi_setup.py",
+        "../versioneer.py"
     ]
 
     argv = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to pysharedmem's documentation!
-======================================
+=======================================
 
 Contents:
 


### PR DESCRIPTION
When using our boilerplate solution shared on the rtfd issue tracker, accidentally replaced some crucial bits regarding ignored paths and our comment. This reverts those changes.